### PR TITLE
Use ONLY line-height for paragraph-indent (drop text-indent)

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -175,10 +175,6 @@
 
     > li {
         margin-bottom: 0px;
-        /* $spacing-unit; */
-        p {
-            text-indent: 1.5em;
-        }
     }
 }
 
@@ -213,10 +209,6 @@
 
 .post-content {
     margin-bottom: $spacing-unit;
-
-    p {
-        text-indent: 1.5em;
-    }
 
     h1 {
         text-align: center;


### PR DESCRIPTION
According to popular typography web-guide
( http://practicaltypography.com/summary-of-key-rules.html #17)
it is good to use text-indent OR line-height, but not both.
I think it has reason.

Also take a look
* http://habrahabr.ru/
* https://blog.yandex.ru/

I think that guys know smthing ;)